### PR TITLE
CU-1mf12zx: Cmd-k in the search bar is not OS-friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commandbar-launcher",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "commandbar-launcher",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/os.js
+++ b/src/components/os.js
@@ -16,7 +16,7 @@ const os = () => {
     os = "WINDOWS";
   } else if (/Android/.test(userAgent)) {
     os = "ANDROID";
-  } else if (!os && /Linux/.test(platform)) {
+  } else if (/Linux/.test(platform)) {
     os = "LINUX";
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -41,9 +41,9 @@
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  padding: 0.2em 0 0;
+  padding: 0.2em 0.5em 0;
   margin: 0 0 -10px;
-  width: 2em;
+  min-width: 2em;
   height: 2em;
   background-color: rgba(170, 170, 180);
   color: white;


### PR DESCRIPTION
The issue was appeared because of the always `false` value in the Linux detection condition. 

### Changes:
 - Fix Linux detection condition
 - Adjust styes

#### Showcase:
![Screenshot 2021-12-26 at 15 11 38](https://user-images.githubusercontent.com/5692090/147409318-42131c96-a57a-44b2-a87e-77c079c95dee.png)
 